### PR TITLE
Sinobit scrolling Chinese font

### DIFF
--- a/source/LED-Matrix.cpp
+++ b/source/LED-Matrix.cpp
@@ -135,6 +135,18 @@ void HT1632C_Write_Pattern(const uint16_t pattern[])
   }
 }
 
+/*
+ * Write pattern to display from cyclic buffer
+ */
+void HT1632C_Write_Pattern(const uint16_t pattern[], uint16_t start_col, uint16_t max_col)
+{
+  uint16_t col= start_col;
+  for (int c=0; c<12; c++) {
+    HT1632C_Write_DAT(com[c],pattern,col++);
+    if (col >= max_col) col=0;
+  }
+}
+
 void HT1632C_Read_Pattern(uint16_t pattern[])
 {
   for (int col=0; col<12; col++) {

--- a/source/LED-Matrix.h
+++ b/source/LED-Matrix.h
@@ -5,4 +5,5 @@ void HT1632C_clr(void); //Clear function
 void HT1632C_Init(void); //HT1632C Init Function
 void HT1632C_Read_DATA(unsigned char Addr);
 void HT1632C_Write_Pattern(const uint16_t pattern[]);
+void HT1632C_Write_Pattern(const uint16_t pattern[], uint16_t start_col, uint16_t max_col);
 void HT1632C_Read_Pattern(uint16_t pattern[]);

--- a/source/font.cpp
+++ b/source/font.cpp
@@ -34,7 +34,7 @@ void WriteGlyph(const uint8_t glyph[18])
     HT1632C_Write_Pattern(bitmap);
 }
 
-void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t delay)
+void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t scroll_delay, uint32_t char_delay)
 {
     static uint16_t bitmap[24]; // double width buffer
     static uint16_t column= 0;
@@ -50,22 +50,27 @@ void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length
             ExpandGlyph(font[text[letter++]], bitmap+column);
             column= 12-column;
         }
-        HT1632C_Write_Pattern(bitmap, col++, 24);
+        HT1632C_Write_Pattern(bitmap, col, 24);
+        busy_wait(col++ % 12 ? scroll_delay : char_delay);
         if (col > 23) col= 0;
-        busy_wait(delay);
     }
     for (int c= 0; c < 12; c++) { // display the last glyph
-        HT1632C_Write_Pattern(bitmap, col++, 24);
-        col%= 24;
-        busy_wait(delay);
+        HT1632C_Write_Pattern(bitmap, col, 24);
+        busy_wait(col++ % 12 ? scroll_delay : char_delay);
+        if (col > 23) col= 0;
     }
     for (int c= 0; c < 12; c++) { // clear final display
         bitmap[column++]= 0;
         if (column > 23) column= 0;
     }
     for (int c= 0; c < 12; c++) { // shift out the last glyph
-        HT1632C_Write_Pattern(bitmap, col++, 24);
-        col%= 24;
-        busy_wait(delay);
+        HT1632C_Write_Pattern(bitmap, col, 24);
+        busy_wait(col++ % 12 ? scroll_delay : char_delay);
+        if (col > 23) col= 0;
     }
+}
+
+void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t delay)
+{
+    ScrollText(font, text, length, delay, delay);
 }

--- a/source/font.h
+++ b/source/font.h
@@ -8,3 +8,5 @@ extern const uint8_t glyph[][18];
 
 void ExpandGlyph(const uint8_t glyph[18], uint16_t *bitmap);
 void WriteGlyph(const uint8_t glyph[18]);
+
+void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t delay);

--- a/source/font.h
+++ b/source/font.h
@@ -10,3 +10,4 @@ void ExpandGlyph(const uint8_t glyph[18], uint16_t *bitmap);
 void WriteGlyph(const uint8_t glyph[18]);
 
 void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t delay);
+void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t scroll_delay, uint32_t char_delay);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -16,33 +16,8 @@
 //#include <nrf51.h> // redundant, just to make Eclipse happy
 //#include <core_cm0.h> // redundant, just to make Eclipse happy
 
-const uint16_t pattern[]= {
-    0b0000000000000000,
-    0b0000000000010000,
-    0b0000000000110000,
-    0b0000000001110000,
-    0b0000000011110000,
-    0b0000000111110000,
-    0b0000001111110000,
-    0b0000011111110000,
-    0b0000111111110000,
-    0b0001111111110000,
-    0b0011111111110000,
-    0b0111111111110000,
-    0b1111111111110000,
-    0b1111111111100000,
-    0b1111111111000000,
-    0b1111111110000000,
-    0b1111111100000000,
-    0b1111111000000000,
-    0b1111110000000000,
-    0b1111100000000000,
-    0b1111000000000000,
-    0b1110000000000000,
-    0b1100000000000000,
-    0b1000000000000000
-};
-const uint16_t patternlength= sizeof(pattern)/sizeof(uint16_t);
+const uint16_t sinotext[]= {21, 8};
+const uint16_t sinolength= sizeof(sinotext)/sizeof(uint16_t);
 
 Cereal cereal(USBTX, USBRX);
 
@@ -128,15 +103,10 @@ int main(void) {
 
  considered_harmful:
   cereal.puts("Scrolling message\r\n");
-  for (int16_t c= 0; c<patternlength; c++) {
-      HT1632C_Write_Pattern(pattern, c, patternlength);
-      cereal.putdigits(c,10,2);
-      cereal.crlf();
-      delay(1<<20);
-  }
+  ScrollText(glyph, sinotext, sinolength, 1<<18);
   cereal.puts("Scrolling done\r\n");
 
-  //delay(1<<20);
+  delay(1<<20);
 
   goto considered_harmful;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,6 +1,6 @@
 /**
  * This is an minimialistic Proof-of-Concept
- * of direct register level programming
+ * of Chinese scrolling text display
  * that bypasses all higher level libraries and runtimes
  *
  * @copyright (c) Christoph Maier
@@ -18,6 +18,9 @@
 
 const uint16_t sinotext[]= {21, 8};
 const uint16_t sinolength= sizeof(sinotext)/sizeof(uint16_t);
+
+const uint16_t blktext[]= {2654, 1572};
+const uint16_t blklength= sizeof(blktext)/sizeof(uint16_t);
 
 Cereal cereal(USBTX, USBRX);
 
@@ -102,11 +105,11 @@ int main(void) {
   //putIRQenables();
 
  considered_harmful:
-  cereal.puts("Scrolling message\r\n");
-  ScrollText(glyph, sinotext, sinolength, 1<<18);
+  cereal.puts("Scrolling message 1\r\n");
+  ScrollText(glyph, sinotext, sinolength, 1<<18, 1<<20);
+  cereal.puts("Scrolling message 2\r\n");
+  ScrollText(glyph, blktext, blklength, 1<<18, 1<<20);
   cereal.puts("Scrolling done\r\n");
-
   delay(1<<20);
-
   goto considered_harmful;
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -16,8 +16,35 @@
 //#include <nrf51.h> // redundant, just to make Eclipse happy
 //#include <core_cm0.h> // redundant, just to make Eclipse happy
 
-Cereal cereal(USBTX, USBRX);
+const uint16_t pattern[]= {
+    0b0000000000000000,
+    0b0000000000010000,
+    0b0000000000110000,
+    0b0000000001110000,
+    0b0000000011110000,
+    0b0000000111110000,
+    0b0000001111110000,
+    0b0000011111110000,
+    0b0000111111110000,
+    0b0001111111110000,
+    0b0011111111110000,
+    0b0111111111110000,
+    0b1111111111110000,
+    0b1111111111100000,
+    0b1111111111000000,
+    0b1111111110000000,
+    0b1111111100000000,
+    0b1111111000000000,
+    0b1111110000000000,
+    0b1111100000000000,
+    0b1111000000000000,
+    0b1110000000000000,
+    0b1100000000000000,
+    0b1000000000000000
+};
+const uint16_t patternlength= sizeof(pattern)/sizeof(uint16_t);
 
+Cereal cereal(USBTX, USBRX);
 
 uint16_t readpattern[12]; // pattern read back
 
@@ -99,25 +126,17 @@ int main(void) {
   //cereal.puts("Ja! Beiherhundt das oder die Flipperwaldt gersput!\r\n");
   //putIRQenables();
 
-  unsigned int ofs=0;
  considered_harmful:
-  WriteGlyph(glyph[ofs]);
+  cereal.puts("Scrolling message\r\n");
+  for (int16_t c= 0; c<patternlength; c++) {
+      HT1632C_Write_Pattern(pattern, c, patternlength);
+      cereal.putdigits(c,10,2);
+      cereal.crlf();
+      delay(1<<20);
+  }
+  cereal.puts("Scrolling done\r\n");
 
-  cereal.crlf();
-  cereal.putdigits(ofs,10);
-  cereal.crlf();
-  for (int b=0; b<3; cereal.puthex(charcode[ofs][b++],2));
-  cereal.crlf();
-  ++ofs;
-  ofs%=8105;
-
-  HT1632C_Read_Pattern(readpattern);
-  printpattern(readpattern);
-
-  delay(1<<20);
-
-  //cereal.putreg(&gpiobase->DIR, "Dir  ");
-  //cereal.putreg(&gpiobase->IN, "In   ");
+  //delay(1<<20);
 
   goto considered_harmful;
 }


### PR DESCRIPTION
I have added a left-to-right reading direction scroll feature for the Chinese font display on the sino:bit. 
It does not use libraries for multiple devices or abstraction layers, but drives the sino:bit display rather directly. 
The function 
`void ScrollText(const uint8_t font[][18], const uint16_t text[], uint32_t length, uint32_t scroll_delay, uint32_t char_delay);` 
uses 
- a fixed size 12x12 bitmap `font`, with the glyphs formatted as described in a previous pull request
- a `text` comprised of indices into the font array
- the text `length`
- the `scroll_delay` between scrolling steps
- the `char_delay` when a character has been scrolled into position

So far, the delays are implemented as busy wait routines. 
These minimalist routines should be embedded into more sophisticated operating systems.

So far, the font is missing Chinese punctuation marks, and some Latin letters and numbers probably need to be added yet, too. 